### PR TITLE
remove `barWrap.innerHTML = ''` to restore the original toolbar

### DIFF
--- a/logseq-mind-mapping/index.js
+++ b/logseq-mind-mapping/index.js
@@ -154,7 +154,6 @@ function initMindMap (el, btnClose, data) {
 
   const patchRightBottomBar = () => {
     const barWrap = document.querySelector('toolbar.rb')
-    barWrap.innerHTML = ''
     barWrap.appendChild(btnClose)
   }
 


### PR DESCRIPTION
- the line `barWrap.innerHTML = ''` deletes the original mind-elixir toolbar
- removing this line will restore the original toolbar (controls to zoom and center view) and appends the `CLOSE` button at its end
![image](https://user-images.githubusercontent.com/4605693/122386256-014b5b00-cf6e-11eb-8a11-7581a11c19f4.png)
