### PR TITLE
Added targets attribute to package.json

### DIFF
--- a/logseq-reddit-hot-news/package.json
+++ b/logseq-reddit-hot-news/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Read r/logseq hot news using Logseq blocks.",
   "main": "dist/index.html",
+  "targets": { "main": false },
   "repository": {
     "type": "git",
     "url": "https://github.com/logseq/logseq-plugin-samples/tree/master/logseq-reddit-hot-news"


### PR DESCRIPTION
Encountered `@parcel/core: Unexpected output file type .html in target "main"` when trying to run `npm build`. Unable to fix it by changing from `main` to `default` as the plugin will not run.