### PR TITLE
Fix: Pomodoro timer rerender

### DIFF
--- a/logseq-pomodoro-timer/index.ts
+++ b/logseq-pomodoro-timer/index.ts
@@ -88,7 +88,7 @@ async function main () {
     if (!startTime) return
     const durationTime = (durationMins || 25) * 60 // default 20 minus
 
-    const keepKey = `${pomoId}-${slotId}-${logseq.baseInfo.id}`
+    const keepKey = `${logseq.baseInfo.id}--${pomoId}`
     const keepOrNot = () => logseq.App.queryElementById(keepKey)
 
     function _render (init: boolean) {


### PR DESCRIPTION
This resolves #26. Since the key has changed on commit https://github.com/logseq/logseq/commit/5a3e93f9305d4cbf720b8f59d6f078dd328d02ef 